### PR TITLE
Add `checkout` option to disable checkout of the repository in the vm

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ With the `post-run` input, you can run commands _outside_ of the VM before the V
       echo "Hello from outside the VM!"
 ```
 
+### `checkout`
+
+By default, the action will clone the repository into the VM. You can disable this behavior by setting `checkout` to `false`, which will disable the `actions/checkout` child action.
+
 ### `continue-on-error`
 
 By default, the action will abort if the `run` script returns a non-zero exit code. You can override this behavior by setting `continue-on-error` to `true`, which will guarantee that the `post-run` script is run.

--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,10 @@ inputs:
         --copy-links \
         --exclude-from "$exclude_path" \
         firecracker: .
+  checkout:
+    required: false
+    type: boolean
+    default: true
   continue-on-error:
     required: false
     type: boolean
@@ -79,6 +83,7 @@ runs:
 
   steps:
     - name: Checkout
+      if: inputs.checkout == 'true'
       uses: actions/checkout@v4
       with:
         path: firecracker-freebsd


### PR DESCRIPTION
Tested in https://github.com/astral-sh/uv/pull/9627; though it did not resolve my problem, it skipped the checkout correctly.

- [checkout: false](https://github.com/astral-sh/uv/actions/runs/12153292861/job/33891143150)
- [checkout: true](https://github.com/astral-sh/uv/actions/runs/12153394097/job/33891436968)

Arguably since this doesn't solve my problem it shouldn't be added, i.e., there is no longer a justification, but I do think it's reasonable to have. I'd still use it, since it saves space and time.

I don't feel strongly about the default behavior. Keeping the default of `true` makes some sense, given that you need to configure the `rsync` manually.

Closes #1