### PR TITLE
Pin `actions/checkout` to a commit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ runs:
   steps:
     - name: Checkout
       if: inputs.checkout == 'true'
-      uses: actions/checkout@v4
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       with:
         path: firecracker-freebsd
 


### PR DESCRIPTION
GitHub now allows enforcing pinning actions to commits, which is more secure because tags can be moved. https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/

I tried turning this on in uv, since we're particularly security conscious, and it looks like the policy is applied to transitive action usage as performed here. e.g., see https://github.com/astral-sh/uv/actions/runs/17001407277/job/48221354978

This adds a pin to `actions/checkout` here.