### PR TITLE
Wait for Firecracker to exit before retrying

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -232,7 +232,8 @@ runs:
             break
           else
             echo "Attempt $vm_start_attempt: Firecracker VM did not start, retrying..."
-            kill $firecracker_pid || true
+            kill "$firecracker_pid" || true
+            wait "$firecracker_pid" || true
 
             echo "::group::ℹ️ Firecracker VM log (attempt $vm_start_attempt)"
             cat $LOGFILE


### PR DESCRIPTION
We're seeing a lot of flakes in this action recently, I suspect it's instability on GitHub's end but when investigating I found a subtle bug that reduces the efficacy of retries.

On retry, starting the next process immediately after sending `SIGTERM` can race with teardown and leave `tap0` busy, causing the attempt to fail with `Open tap device failed: Resource busy`. We've seen this empirically in [uv](https://github.com/astral-sh/uv/actions/runs/29022702260/job/86134074512).

Waiting for the process ensures the interface is released before retrying, so we don't waste retry attempts.
