### PR TITLE
Fix FreeBSD startup on Intel hosts without a frequency

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -173,6 +173,30 @@ runs:
         # important that `TAP_IP` and `FC_MAC` match this.
         FC_MAC="06:00:AC:10:00:02"
 
+        cpu_config='{}'
+        if grep -qm1 '^vendor_id[[:space:]]*: GenuineIntel' /proc/cpuinfo \
+          && ! grep -m1 '^model name' /proc/cpuinfo | grep -Eq '[0-9.]+[GMT]Hz'; then
+          echo "Host CPU brand string does not include a frequency; advertising a temporary 4000 MHz base frequency to the guest"
+          # The FreeBSD Firecracker kernel cannot calibrate the TSC until later
+          # in boot. CPUID.16 supplies an approximate frequency for early delays;
+          # FreeBSD recalibrates it once kvmclock is available.
+          cpu_config='{
+            "cpuid_modifiers": [
+              {
+                "leaf": "0x16",
+                "subleaf": "0x0",
+                "flags": 0,
+                "modifiers": [
+                  {
+                    "register": "eax",
+                    "bitmap": "0b00000000000000000000111110100000"
+                  }
+                ]
+              }
+            ]
+          }'
+        fi
+
         cat <<EOF > vmconfig.json
         {
           "boot-source": {
@@ -194,6 +218,7 @@ runs:
                   "host_dev_name": "$TAP_DEV"
               }
           ],
+          "cpu-config": $cpu_config,
           "machine-config": {
             "vcpu_count": 2,
             "mem_size_mib": 5120,

--- a/action.yml
+++ b/action.yml
@@ -177,9 +177,11 @@ runs:
         if grep -qm1 '^vendor_id[[:space:]]*: GenuineIntel' /proc/cpuinfo \
           && ! grep -m1 '^model name' /proc/cpuinfo | grep -Eq '[0-9.]+[GMT]Hz'; then
           echo "Host CPU brand string does not include a frequency; advertising a temporary 4000 MHz base frequency to the guest"
-          # The FreeBSD Firecracker kernel cannot calibrate the TSC until later
-          # in boot. CPUID.16 supplies an approximate frequency for early delays;
-          # FreeBSD recalibrates it once kvmclock is available.
+          # The FreeBSD Firecracker kernel skips early TSC calibration. Firecracker
+          # normally includes the Intel host's brand-string frequency in guest
+          # CPUID, but some GitHub runner CPUs (e.g. 8573C) omit it. That leaves
+          # tsc_freq at zero and panics during LAPIC initialization. Supply a
+          # conservative CPUID.16 value; FreeBSD recalibrates it with kvmclock later.
           cpu_config='{
             "cpuid_modifiers": [
               {


### PR DESCRIPTION
On Intel GitHub Actions runners whose CPU brand string omits a frequency, FreeBSD can panic with `TSC not initialized` during LAPIC initialization on every VM start ([example](https://github.com/zanieb/freebsd-firecracker-action/actions/runs/29033758959/job/86173135668)). Firecracker cannot derive an early guest TSC frequency from these hosts, while the FreeBSD Firecracker kernel skips early TSC calibration, leaving `tsc_freq` at zero.

Detect affected Intel hosts and provide a conservative base frequency through CPUID.16 in the VM configuration. This supplies the frequency FreeBSD needs during early boot; FreeBSD recalibrates it with kvmclock later. Other Intel hosts and AMD hosts retain the existing configuration.
